### PR TITLE
Add explicit import for `urllib.error` in `eventsFeed.py` to fix Pylance `reportAttributeAccessIssue`

### DIFF
--- a/eventsfeed/eventsFeed.py
+++ b/eventsfeed/eventsFeed.py
@@ -79,6 +79,7 @@ import sys
 import time
 import urllib.parse
 import urllib.request
+import urllib.error
 
 
 ########################################################################################


### PR DESCRIPTION
Pylance reports an `reportAttributeAccessIssue` error in `eventsFeed.py` in its default configuration.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/6b97b73a-02e0-46e7-9a50-f8f9adb1e54b" />

This is resolved by adding an explicit import for `urllib.error`.